### PR TITLE
Add initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@
 ## Super Quick Start
 
 ```
-$ web-ext run -s extension --pref "extensions.experiments.enabled=true"
+$ yarn install
+$ yarn web-ext run -s extension --pref "extensions.experiments.enabled=true"
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
 # addons-search-experiment
+
+## Super Quick Start
+
+```
+$ web-ext run -s extension --pref "extensions.experiments.enabled=true"
+```

--- a/extension/api.js
+++ b/extension/api.js
@@ -124,15 +124,15 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
                 return;
               }
 
-              fire.async();
+              searchInitialized.then(() => {
+                fire.async();
+              });
             };
 
-            searchInitialized.then(() => {
-              Services.obs.addObserver(
-                onSearchEngineModifiedObserver,
-                SEARCH_TOPIC_ENGINE_MODIFIED
-              );
-            });
+            Services.obs.addObserver(
+              onSearchEngineModifiedObserver,
+              SEARCH_TOPIC_ENGINE_MODIFIED
+            );
 
             return () => {
               Services.obs.removeObserver(

--- a/extension/api.js
+++ b/extension/api.js
@@ -1,0 +1,154 @@
+/* global ExtensionCommon, ExtensionAPI, Services, XPCOMUtils */
+const { SearchUtils } = ChromeUtils.import(
+  "resource://gre/modules/SearchUtils.jsm"
+);
+const { WebRequest } = ChromeUtils.import(
+  "resource://gre/modules/WebRequest.jsm"
+);
+const { AddonManager } = ChromeUtils.import(
+  "resource://gre/modules/AddonManager.jsm"
+);
+
+XPCOMUtils.defineLazyGlobalGetters(this, ["ChannelWrapper"]);
+
+XPCOMUtils.defineLazyServiceGetter(
+  Services,
+  "eTLD",
+  "@mozilla.org/network/effective-tld-service;1",
+  "nsIEffectiveTLDService"
+);
+
+this.addonsSearchExperiment = class extends ExtensionAPI {
+  onStartup() {}
+
+  makeOnSearchEngineModified(context) {
+    return new ExtensionCommon.EventManager({
+      context,
+      name: "addonsSearchExperiment.onSearchEngineModified",
+      register: (fire) => {
+        const onSearchEngineModifiedObserver = {
+          observe(aSubject, aTopic, aData) {
+            if (aTopic !== SearchUtils.TOPIC_ENGINE_MODIFIED) {
+              return;
+            }
+
+            fire.async(aData);
+          },
+        };
+
+        Services.obs.addObserver(
+          onSearchEngineModifiedObserver,
+          SearchUtils.TOPIC_ENGINE_MODIFIED
+        );
+
+        return () => {
+          Services.obs.removeObserver(
+            onSearchEngineModifiedObserver,
+            SearchUtils.TOPIC_ENGINE_MODIFIED
+          );
+        };
+      },
+    }).api();
+  }
+
+  getAPI(context) {
+    return {
+      addonsSearchExperiment: {
+        // `getMatchPatterns()` returns a map where each key is an URL pattern
+        // to monitor and its corresponding value is an add-on ID (search
+        // engine).
+        //
+        // Note: We don't return a simple list of URL patterns because the
+        // background script might want to lookup the add-on ID for a given
+        // URL.
+        async getMatchPatterns() {
+          const patterns = {};
+
+          try {
+            const visibleEngines = await Services.search.getVisibleEngines();
+
+            visibleEngines.forEach((engine) => {
+              let { _extensionID, _urls } = engine;
+
+              _urls.forEach(({ template }) => {
+                // If this is changed, double check the code in the background
+                // script because `webRequestCancelledHandler` splits patterns
+                // on `*` to retrieve URL prefixes.
+                const pattern = template.split("?")[0] + "*";
+                patterns[pattern] = _extensionID;
+              });
+            });
+          } catch (err) {
+            Cu.reportError(err);
+          }
+
+          return patterns;
+        },
+
+        // `getRequestProperty()` returns the property identified by
+        // `propertyName` for a given `requestId` (= channel ID). This might
+        // not return a value if the channel does not exist anymore or there is
+        // no such property.
+        async getRequestProperty(requestId, propertyName) {
+          const wrapper = ChannelWrapper.getRegisteredChannel(
+            requestId,
+            context.extension.policy,
+            context.xulBrowser.frameLoader.remoteTab
+          );
+
+          try {
+            return wrapper?.channel
+              ?.QueryInterface(Ci.nsIPropertyBag)
+              ?.getProperty(propertyName);
+          } catch {
+            // It is possible the property does not exist (or everything
+            // miserably failed).
+            return null;
+          }
+        },
+
+        // `getRequestUrl()` returns the original URL of a request given its
+        // ID. This is needed when a request has been redirected and we want to
+        // retrieve the new URL after the redirect.
+        async getRequestUrl(requestId) {
+          const wrapper = ChannelWrapper.getRegisteredChannel(
+            requestId,
+            context.extension.policy,
+            context.xulBrowser.frameLoader.remoteTab
+          );
+
+          return wrapper?.channel?.name;
+        },
+
+        // `getAddonById()` returns add-on details if it exists. Note that it
+        // does not return a full `add-on` object but a minimal object with
+        // only the necessary information.
+        async getAddonById(addonId) {
+          const addon = await AddonManager.getAddonByID(addonId);
+
+          return { version: addon.version };
+        },
+
+        // `getPublicSuffix()` returns the public suffix/Effective TLD Service
+        // of the given URL.
+        // See: https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIEffectiveTLDService
+        async getPublicSuffix(url) {
+          try {
+            return Services.eTLD.getBaseDomain(Services.io.newURI(url));
+          } catch (err) {
+            Cu.reportError(err);
+            return null;
+          }
+        },
+
+        // `onSearchEngineModified` is an event that occurs when the list of
+        // search engines has changed, e.g., a new engine has been added or an
+        // engine has been removed. Listeners receive the type of modification,
+        // e.g., `engine-added`, `engine-removed`, etc.
+        //
+        // See: https://searchfox.org/mozilla-central/source/toolkit/components/search/SearchUtils.jsm#145-152
+        onSearchEngineModified: this.makeOnSearchEngineModified(context),
+      },
+    };
+  }
+};

--- a/extension/api.js
+++ b/extension/api.js
@@ -109,7 +109,9 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
               if (
                 aTopic !== SEARCH_TOPIC_ENGINE_MODIFIED ||
                 // We are only interested in these modified types.
-                !["engine-added", "engine-removed"].includes(aData)
+                !["engine-added", "engine-removed", "engine-changed"].includes(
+                  aData
+                )
               ) {
                 return;
               }

--- a/extension/api.js
+++ b/extension/api.js
@@ -185,15 +185,6 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
                 Cu.reportError(err);
               }
 
-              let redirectChain;
-              try {
-                redirectChain = channel?.loadInfo?.redirectChain.map(
-                  (entry) => entry.principal.spec
-                );
-              } catch (err) {
-                Cu.reportError(err);
-              }
-
               const firstUrl = this.firstMatchedUrls[requestId];
               // We don't need this entry anymore.
               delete this.firstMatchedUrls[requestId];
@@ -210,16 +201,16 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
             };
 
             const listener = ({ requestId, url }) => {
-              const wrapper = ChannelWrapper.getRegisteredChannel(
-                requestId,
-                context.extension.policy,
-                context.xulBrowser.frameLoader.remoteTab
-              );
-
               // Keep the first monitored URL that was redirected for the
               // request until the request has stopped.
               if (!this.firstMatchedUrls[requestId]) {
                 this.firstMatchedUrls[requestId] = url;
+
+                const wrapper = ChannelWrapper.getRegisteredChannel(
+                  requestId,
+                  context.extension.policy,
+                  context.xulBrowser.frameLoader.remoteTab
+                );
 
                 wrapper.addEventListener("stop", stopListener);
               }

--- a/extension/api.js
+++ b/extension/api.js
@@ -164,7 +164,9 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
                 Cu.reportError(err);
               }
 
-              fire.async({ addonId, redirectUrl, requestId, url });
+              // We make in synchronous so that the event is not delayed and
+              // the order of the events is respected.
+              fire.sync({ addonId, redirectUrl, requestId, url });
             };
 
             WebRequest.onBeforeRedirect.addListener(

--- a/extension/api.js
+++ b/extension/api.js
@@ -30,8 +30,6 @@ XPCOMUtils.defineLazyGetter(global, "searchInitialized", () => {
 });
 
 this.addonsSearchExperiment = class extends ExtensionAPI {
-  onStartup() {}
-
   getAPI(context) {
     return {
       addonsSearchExperiment: {

--- a/extension/api.js
+++ b/extension/api.js
@@ -50,21 +50,24 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
             visibleEngines.forEach((engine) => {
               let { _extensionID, _urls } = engine;
 
-              _urls.forEach(({ template }) => {
-                // If this is changed, double check the code in the background
-                // script because `webRequestCancelledHandler` splits patterns
-                // on `*` to retrieve URL prefixes.
-                const pattern = template.split("?")[0] + "*";
+              _urls
+                // We don't want to include "suggestion" URLs.
+                .filter(({ type }) => type === "text/html")
+                .forEach(({ template }) => {
+                  // If this is changed, double check the code in the background
+                  // script because `webRequestCancelledHandler` splits patterns
+                  // on `*` to retrieve URL prefixes.
+                  const pattern = template.split("?")[0] + "*";
 
-                // Multiple search engines could register URL templates that
-                // would become the same URL pattern as defined above so we
-                // store a list of extension IDs per URL pattern.
-                if (!patterns[pattern]) {
-                  patterns[pattern] = [_extensionID];
-                } else if (!patterns[pattern].includes(_extensionID)) {
-                  patterns[pattern].push(_extensionID);
-                }
-              });
+                  // Multiple search engines could register URL templates that
+                  // would become the same URL pattern as defined above so we
+                  // store a list of extension IDs per URL pattern.
+                  if (!patterns[pattern]) {
+                    patterns[pattern] = [_extensionID];
+                  } else if (!patterns[pattern].includes(_extensionID)) {
+                    patterns[pattern].push(_extensionID);
+                  }
+                });
             });
           } catch (err) {
             Cu.reportError(err);

--- a/extension/api.js
+++ b/extension/api.js
@@ -63,8 +63,15 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
                   // would become the same URL pattern as defined above so we
                   // store a list of extension IDs per URL pattern.
                   if (!patterns[pattern]) {
-                    patterns[pattern] = [_extensionID];
-                  } else if (!patterns[pattern].includes(_extensionID)) {
+                    patterns[pattern] = [];
+                  }
+
+                  // We exclude built-in search engines because we don't need
+                  // to report them.
+                  if (
+                    !patterns[pattern].includes(_extensionID) &&
+                    !_extensionID.endsWith("@search.mozilla.org")
+                  ) {
                     patterns[pattern].push(_extensionID);
                   }
                 });

--- a/extension/api.js
+++ b/extension/api.js
@@ -45,7 +45,7 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
 
           try {
             await searchInitialized;
-            const visibleEngines = await Services.search.getVisibleEngines();
+            const visibleEngines = await Services.search.getEngines();
 
             visibleEngines.forEach((engine) => {
               let { _extensionID, _urls } = engine;

--- a/extension/api.js
+++ b/extension/api.js
@@ -126,7 +126,11 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
           },
         }).api(),
 
-        // TODO: documentation
+        // `onBeforeRedirect` is an event very similar to the public web
+        // request `onBeforeRedirect` but it is registered in the privileged
+        // code to make sure that we can read properties on a valid channel
+        // (wrapper). The registered listeners will received the `addonId` in
+        // addition to these props: `requestId`, `url` and `redirectUrl`.
         onBeforeRedirect: new ExtensionCommon.EventManager({
           context,
           name: "addonsSearchExperiment.onBeforeRedirect",

--- a/extension/api.js
+++ b/extension/api.js
@@ -39,7 +39,8 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
         // (search engines).
         //
         // Note: We don't return a simple list of URL patterns because the
-        // background script might want to lookup add-on IDs for a given URL.
+        // background script might want to lookup add-on IDs for a given URL in
+        // the case of server-side redirects.
         async getMatchPatterns() {
           const patterns = {};
 

--- a/extension/api.js
+++ b/extension/api.js
@@ -51,7 +51,8 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
               let { _extensionID, _urls } = engine;
 
               _urls
-                // We don't want to include "suggestion" URLs.
+                // We only want to collect "search URLs" (and not "suggestion"
+                // ones for instance). See `URL_TYPE` in `SearchUtils.jsm`.
                 .filter(({ type }) => type === "text/html")
                 .forEach(({ template }) => {
                   // If this is changed, double check the code in the background

--- a/extension/api.js
+++ b/extension/api.js
@@ -176,7 +176,7 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
                 Cu.reportError(err);
               }
 
-              // We make in synchronous so that the event is not delayed and
+              // We make it synchronous so that the event is not delayed and
               // the order of the events is respected.
               fire.sync({ addonId, redirectUrl, requestId, url });
             };

--- a/extension/api.js
+++ b/extension/api.js
@@ -107,9 +107,7 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
                 return;
               }
 
-              searchInitialized.then(() => {
-                fire.async();
-              });
+              fire.async();
             };
 
             Services.obs.addObserver(
@@ -154,27 +152,20 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
               fire.async({ addonId, redirectUrl, requestId, url });
             };
 
-            // See: toolkit/components/extensions/parent/ext-webRequest.js
-            let filter2 = {};
-            if (filter.urls) {
-              let perms = new MatchPatternSet([
-                ...extension.allowedOrigins.patterns,
-                ...extension.optionalOrigins.patterns,
-              ]);
-
-              filter2.urls = ExtensionUtils.parseMatchPatterns(filter.urls);
-            }
-
             WebRequest.onBeforeRedirect.addListener(
               listener,
-              filter2,
+              // filter
+              {
+                types: ["main_frame"],
+                urls: ExtensionUtils.parseMatchPatterns(filter.urls),
+              },
               // info
               [],
               // listener details
               {
                 addonId: extension.id,
                 policy: extension.policy,
-                blockingAllowed: extension.hasPermission("webRequestBlocking"),
+                blockingAllowed: false,
               }
             );
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -79,26 +79,18 @@ class AddonsSearchExperiment {
     );
 
     console.debug("registering onBeforeRedirect listener");
-    browser.webRequest.onBeforeRedirect.addListener(this.webRequestHandler, {
-      urls: patterns,
-    });
+    browser.addonsSearchExperiment.onBeforeRedirect.addListener(
+      this.webRequestHandler,
+      { urls: patterns }
+    );
   }
 
   noOpHandler = () => {
     // Do nothing.
   };
 
-  webRequestHandler = async ({ requestId, url, redirectUrl }) => {
-    // When we detect a redirect, we read the request property, hoping to find
-    // an add-on ID corresponding to the add-on that initiated the redirect.
-    // It might not return anything when the redirect is a search server-side
-    // redirect but it can also be caused by an error.
-    let addonId = await browser.addonsSearchExperiment.getRequestProperty(
-      requestId,
-      "redirectedByExtension"
-    );
-
-    // When we did not find an add-on ID in the request property bag and the
+  webRequestHandler = async ({ addonId, redirectUrl, requestId, url }) => {
+    // When we do not have an add-on ID (in the request property bag) and the
     // `redirectUrl` is different than the original URL. we likely detected a
     // search server-side redirect.
     const isServerSideRedirect = !addonId && url !== redirectUrl;

--- a/extension/background.js
+++ b/extension/background.js
@@ -16,7 +16,7 @@ const UNFOLLOW_DELAY_IN_SECONDS = 90;
 
 class AddonsSearchExperiment {
   constructor() {
-    this.matchPatternsMap = {};
+    this.matchPatterns = {};
     // The key is a requestId. The corresponding value should be an object.
     this.requestIdsToFollow = new Map();
 
@@ -33,14 +33,14 @@ class AddonsSearchExperiment {
 
   async getMatchPatterns() {
     try {
-      this.matchPatternsMap =
+      this.matchPatterns =
         await browser.addonsSearchExperiment.getMatchPatterns();
     } catch (err) {
       console.error(`failed to retrieve the list of URL patterns: ${err}`);
-      this.matchPatternsMap = {};
+      this.matchPatterns = {};
     }
 
-    return this.matchPatternsMap;
+    return this.matchPatterns;
   }
 
   // When the search service changes the set of engines that are enabled, we
@@ -70,8 +70,8 @@ class AddonsSearchExperiment {
     //
     // Note: search suggestions are system principal requests, so webRequest
     // cannot intercept them.
-    const matchPatternsMap = await this.getMatchPatterns();
-    const patterns = Object.keys(matchPatternsMap);
+    const matchPatterns = await this.getMatchPatterns();
+    const patterns = Object.keys(matchPatterns);
 
     if (patterns.length === 0) {
       console.debug(
@@ -237,11 +237,11 @@ class AddonsSearchExperiment {
   };
 
   getAddonIdsForUrl(url) {
-    for (const pattern of Object.keys(this.matchPatternsMap)) {
+    for (const pattern of Object.keys(this.matchPatterns)) {
       const [urlPrefix] = pattern.split("*");
 
       if (url.startsWith(urlPrefix)) {
-        return this.matchPatternsMap[pattern];
+        return this.matchPatterns[pattern];
       }
     }
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -63,7 +63,9 @@ class AddonsSearchExperiment {
         this.onRedirectHandler
       );
     }
-
+    // If there is already a listener, remove it so that we can re-add one
+    // after. This is because we're using the same listener with different URL
+    // patterns (when the list of search engines changes).
     if (browser.webRequest.onBeforeRequest.hasListener(this.onRequestHandler)) {
       this.debug("removing onBeforeRequest listener");
       browser.webRequest.onBeforeRequest.removeListener(this.onRequestHandler);

--- a/extension/background.js
+++ b/extension/background.js
@@ -202,7 +202,7 @@ class AddonsSearchExperiment {
       this.listeners[requestId] = listener;
 
       // By simplicity, we use `setTimeout()` to remove the temporary listener,
-      // after 10 seconds.
+      // after 60 seconds.
       setTimeout(() => {
         if (browser.webRequest.onBeforeRequest.hasListener(listener)) {
           console.debug(
@@ -211,7 +211,7 @@ class AddonsSearchExperiment {
           browser.webRequest.onBeforeRequest.removeListener(listener);
           delete this.listeners[requestId];
         }
-      }, 10000);
+      }, 60000);
     }
   }
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -161,11 +161,14 @@ class AddonsSearchExperiment {
     if (maybeServerSideRedirect) {
       this.debug(`start following requestId=${requestId}`);
 
-      // Pass metadata to the follow listener.
-      this.requestIdsToFollow.set(requestId, {
-        addonIds,
-        chain: [url, redirectUrl],
-      });
+      // Pass metadata to the follow listener and "start following" this
+      // request.
+      if (!this.requestIdsToFollow.has(requestId)) {
+        this.requestIdsToFollow.set(requestId, {
+          addonIds,
+          chain: [url, redirectUrl],
+        });
+      }
 
       // If we likely found a server-side redirect, we can stop there and let
       // the follow/unfollow logic do the rest and maybe report an actual
@@ -278,13 +281,10 @@ class AddonsSearchExperiment {
   }
 }
 
-browser.runtime.onInstalled.addListener(({ temporary: debugMode }) => {
-  const exp = new AddonsSearchExperiment({ debugMode });
-  exp.monitor();
+// Set `debugMode` to `true` for development purposes.
+const exp = new AddonsSearchExperiment({ debugMode: false });
+exp.monitor();
 
-  browser.addonsSearchExperiment.onSearchEngineModified.addListener(
-    async () => {
-      await exp.monitor();
-    }
-  );
+browser.addonsSearchExperiment.onSearchEngineModified.addListener(async () => {
+  await exp.monitor();
 });

--- a/extension/background.js
+++ b/extension/background.js
@@ -85,8 +85,6 @@ class AddonsSearchExperiment {
     // search server-side redirect.
     const isServerSideRedirect = !addonId && url !== redirectUrl;
 
-    console.log({ requestId, isServerSideRedirect, addonId, url, redirectUrl });
-
     // Search server-side redirects are possible because an extension has
     // registered a search engine, which is why we can (hopefully) retrieve the
     // add-on ID.

--- a/extension/background.js
+++ b/extension/background.js
@@ -50,6 +50,10 @@ class AddonsSearchExperiment {
       );
     }
 
+    if (browser.webRequest.onBeforeRedirect.hasListener(this.noOpHandler)) {
+      browser.webRequest.onBeforeRedirect.removeListener(this.noOpHandler);
+    }
+
     // Retrieve the list of URL patterns to monitor with our listener.
     //
     // Note: search suggestions are system principal requests, so webRequest
@@ -64,11 +68,22 @@ class AddonsSearchExperiment {
       return;
     }
 
+    // This is needed to force the registration of a traceable channel.
+    browser.webRequest.onBeforeRequest.addListener(
+      this.noOpHandler,
+      { urls: patterns },
+      ["blocking"]
+    );
+
     console.debug("registering onBeforeRedirect listener");
     browser.webRequest.onBeforeRedirect.addListener(this.webRequestHandler, {
       urls: patterns,
     });
   }
+
+  noOpHandler = () => {
+    // Do nothing.
+  };
 
   webRequestHandler = async ({ requestId, url, redirectUrl }) => {
     // When we detect a redirect, we read the request property, hoping to find

--- a/extension/background.js
+++ b/extension/background.js
@@ -37,6 +37,9 @@ class AddonsSearchExperiment {
     return this.matchPatternsMap;
   }
 
+  // When the search service changes the set of engines that are enabled, we
+  // update our pattern matching in the webrequest listeners (go to the bottom
+  // of this file for the search service events we listen to).
   async monitor() {
     // If there is already a listener, remove it so that we can re-add one
     // after. This is because we're using the same listener with different URL

--- a/extension/background.js
+++ b/extension/background.js
@@ -115,7 +115,9 @@ class AddonsSearchExperiment {
     );
 
     if (from === to) {
-      // We do not report redirects to same public suffixes.
+      // We do not report redirects to same public suffixes. However, we will
+      // report redirects from public suffixes belonging to a same entity
+      // (.e.g., `example.com` -> `example.fr`).
       return;
     }
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -246,7 +246,7 @@ class AddonsSearchExperiment {
   // information if needed, then the requestId is removed from the map of
   // request IDs to follow. In addition, when there is no request IDs to
   // follow, we also remove the (wildcard) follow listener.
-  async unfollowRequest({ requestId }) {
+  unfollowRequest({ requestId }) {
     if (this.requestIdsToFollow.has(requestId)) {
       const { addonIds, chain } = this.requestIdsToFollow.get(requestId);
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -101,11 +101,6 @@ class AddonsSearchExperiment {
   }
 
   async onRedirectedListener({ addonId, firstUrl, lastUrl }) {
-    if (!firstUrl || !lastUrl) {
-      // Something went wrong but there is nothing we can do at this point.
-      return;
-    }
-
     // When we do not have an add-on ID (in the request property bag), we
     // likely detected a search server-side redirect.
     const maybeServerSideRedirect = !addonId;
@@ -125,7 +120,7 @@ class AddonsSearchExperiment {
       return;
     }
 
-    // This is the initial URL before any redirect.
+    // This is the monitored URL that was first redirected.
     const from = await browser.addonsSearchExperiment.getPublicSuffix(firstUrl);
     // This is the final URL after redirect(s).
     const to = await browser.addonsSearchExperiment.getPublicSuffix(lastUrl);
@@ -173,7 +168,8 @@ class AddonsSearchExperiment {
 
   getAddonIdsForUrl(url) {
     for (const pattern of Object.keys(this.matchPatterns)) {
-      const [urlPrefix] = pattern.split("*");
+      // `getMatchPatterns()` returns the prefix plus "*".
+      const urlPrefix = pattern.slice(0, -1);
 
       if (url.startsWith(urlPrefix)) {
         return this.matchPatterns[pattern];

--- a/extension/background.js
+++ b/extension/background.js
@@ -179,20 +179,6 @@ class AddonsSearchExperiment {
 const exp = new AddonsSearchExperiment();
 exp.monitor();
 
-browser.addonsSearchExperiment.onSearchEngineModified.addListener(
-  async (type) => {
-    switch (type) {
-      case "engine-added":
-      case "engine-removed":
-        // For these modified types, we want to reload the list of search
-        // engines that are monitored, which is why we break to let the rest
-        // of the code execute.
-        break;
-
-      default:
-        return;
-    }
-
-    await exp.monitor();
-  }
-);
+browser.addonsSearchExperiment.onSearchEngineModified.addListener(async () => {
+  await exp.monitor();
+});

--- a/extension/background.js
+++ b/extension/background.js
@@ -97,14 +97,18 @@ class AddonsSearchExperiment {
     // search server-side redirect.
     const isServerSideRedirect = !addonId && url !== redirectUrl;
 
+    let addonIds = [];
+
     // Search server-side redirects are possible because an extension has
     // registered a search engine, which is why we can (hopefully) retrieve the
     // add-on ID.
     if (isServerSideRedirect) {
-      addonId = this.getAddonIdFromUrl(url);
+      addonIds = this.getAddonIdsForUrl(url);
+    } else if (addonId) {
+      addonIds = [addonId];
     }
 
-    if (!addonId) {
+    if (addonIds.length === 0) {
       // No add-on ID means there is nothing we can report.
       return;
     }
@@ -131,16 +135,18 @@ class AddonsSearchExperiment {
       ? TELEMETRY_VALUE_SERVER
       : TELEMETRY_VALUE_EXTENSION;
 
-    const addonVersion = await browser.addonsSearchExperiment.getAddonVersion(
-      addonId
-    );
+    for (const addonId of addonIds) {
+      const addonVersion = await browser.addonsSearchExperiment.getAddonVersion(
+        addonId
+      );
 
-    this.recordEvent(
-      TELEMETRY_METHOD_ETLD_CHANGE,
-      telemetryObject,
-      telemetryValue,
-      { addonId, addonVersion, from, to }
-    );
+      this.recordEvent(
+        TELEMETRY_METHOD_ETLD_CHANGE,
+        telemetryObject,
+        telemetryValue,
+        { addonId, addonVersion, from, to }
+      );
+    }
   };
 
   recordEvent(method, object, value, extra) {
@@ -159,7 +165,7 @@ class AddonsSearchExperiment {
     );
   }
 
-  getAddonIdFromUrl(url) {
+  getAddonIdsForUrl(url) {
     for (const pattern of Object.keys(this.matchPatternsMap)) {
       const [urlPrefix] = pattern.split("*");
 
@@ -168,7 +174,7 @@ class AddonsSearchExperiment {
       }
     }
 
-    return null;
+    return [];
   }
 }
 

--- a/extension/background.js
+++ b/extension/background.js
@@ -45,16 +45,18 @@ class AddonsSearchExperiment {
     // after. This is because we're using the same listener with different URL
     // patterns (when the list of search engines changes).
     if (
-      browser.webRequest.onBeforeRedirect.hasListener(this.webRequestHandler)
+      browser.addonsSearchExperiment.onBeforeRedirect.hasListener(
+        this.webRequestHandler
+      )
     ) {
       console.debug("removing onBeforeRedirect listener");
-      browser.webRequest.onBeforeRedirect.removeListener(
+      browser.addonsSearchExperiment.onBeforeRedirect.removeListener(
         this.webRequestHandler
       );
     }
 
-    if (browser.webRequest.onBeforeRedirect.hasListener(this.noOpHandler)) {
-      browser.webRequest.onBeforeRedirect.removeListener(this.noOpHandler);
+    if (browser.webRequest.onBeforeRequest.hasListener(this.noOpHandler)) {
+      browser.webRequest.onBeforeRequest.removeListener(this.noOpHandler);
     }
 
     // Retrieve the list of URL patterns to monitor with our listener.

--- a/extension/background.js
+++ b/extension/background.js
@@ -139,7 +139,7 @@ class AddonsSearchExperiment {
     }
   };
 
-  onRedirectHandler = async ({ addonId, redirectUrl, requestId, url }) => {
+  onRedirectHandler = ({ addonId, redirectUrl, requestId, url }) => {
     if (this.requestIdsToFollow.has(requestId)) {
       // When the requestId is already present in the list of request IDs to
       // follow, we don't need to re-execute the logic below.

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,0 +1,230 @@
+"use strict";
+
+const TELEMETRY_CATEGORY = "addonsSearchExperiment";
+// methods
+const TELEMETRY_METHOD_ETLD_CHANGE = "etld_change";
+// objects
+const TELEMETRY_OBJECT_WEBREQUEST = "webrequest";
+const TELEMETRY_OBJECT_OTHER = "other";
+// values
+const TELEMETRY_VALUE_EXTENSION = "extension";
+const TELEMETRY_VALUE_SERVER = "server";
+
+class AddonsSearchExperiment {
+  constructor() {
+    this.matchPatternsMap = {};
+    this.lastRequestIdReported = null;
+
+    console.debug("registering telemetry events");
+    browser.telemetry.registerEvents(TELEMETRY_CATEGORY, {
+      [TELEMETRY_METHOD_ETLD_CHANGE]: {
+        methods: [TELEMETRY_METHOD_ETLD_CHANGE],
+        objects: [TELEMETRY_OBJECT_WEBREQUEST, TELEMETRY_OBJECT_OTHER],
+        extra_keys: ["addonId", "addonVersion", "from", "to"],
+        record_on_release: true,
+      },
+    });
+  }
+
+  async getMatchPatterns() {
+    try {
+      this.matchPatternsMap =
+        await browser.addonsSearchExperiment.getMatchPatterns();
+    } catch (err) {
+      console.error(`failed to retrieve the list of URL patterns: ${err}`);
+      this.matchPatternsMap = {};
+    }
+
+    return this.matchPatternsMap;
+  }
+
+  async monitor() {
+    // If there is already a listener, remove it so that we can re-add one
+    // after. This is because we're using the same listener with different URL
+    // patterns (when the list of search engines changes).
+    if (
+      browser.webRequest.onBeforeRequest.hasListener(this.webRequestHandler)
+    ) {
+      console.debug("removing onBeforeRequest listener");
+      browser.webRequest.onBeforeRequest.removeListener(this.webRequestHandler);
+    }
+
+    if (
+      browser.webRequest.onBeforeRedirect.hasListener(this.webRequestHandler)
+    ) {
+      console.debug("removing onBeforeRedirect listener");
+      browser.webRequest.onBeforeRedirect.removeListener(
+        this.webRequestHandler
+      );
+    }
+
+    // Retrieve the list of URL patterns to monitor with our listener.
+    //
+    // Note: search suggestions are system principal requests, so webRequest
+    // cannot intercept them.
+    const matchPatternsMap = await this.getMatchPatterns();
+    const patterns = Object.keys(matchPatternsMap);
+
+    if (patterns.length === 0) {
+      console.debug(
+        "not registering any listener because there is no URL to monitor"
+      );
+      return;
+    }
+
+    console.debug("registering onBeforeRequest listener");
+    browser.webRequest.onBeforeRequest.addListener(
+      this.webRequestHandler,
+      { urls: patterns },
+      ["blocking"]
+    );
+
+    // This one is needed in addition to `onBeforeRequest` because this
+    // extension might be registered before or after some extensions.
+    // Depending on that, our `onBeforeRequest` listener might not be called,
+    // which is why we also listen to `onBeforeRedirect`.
+    console.debug("registering onBeforeRedirect listener");
+    browser.webRequest.onBeforeRedirect.addListener(this.webRequestHandler, {
+      urls: patterns,
+    });
+  }
+
+  // `redirectUrl` is usually valid when the redirect has been detected via
+  // `onBeforeRedirect`, otherwise it's likely `undefined`.
+  webRequestHandler = async ({ requestId, url, redirectUrl }) => {
+    if (this.lastRequestIdReported === requestId) {
+      console.debug(`request ID '${requestId}' already reported, skipping...`);
+      return;
+    }
+
+    // When we detect a redirect, we read the request property, hoping to find
+    // an add-on ID corresponding to the add-on that initiated the redirect.
+    // It might not return anything when the redirect is a search server-side
+    // redirect but it can also be caused by an error.
+    let addonId = await browser.addonsSearchExperiment.getRequestProperty(
+      requestId,
+      "redirectedByExtension"
+    );
+
+    // When we did not find an add-on ID in the request property bag and the
+    // `redirectUrl` is both valid and different than the original URL. we
+    // likely detected a search server-side redirect.
+    const isServerSideRedirect =
+      !addonId && typeof redirectUrl !== "undefined" && url !== redirectUrl;
+
+    // Search server-side redirects are possible because an extension has
+    // registered a search engine, which is why we can (hopefully) retrieve the
+    // add-on ID.
+    if (isServerSideRedirect) {
+      const id = this.getAddonIdFromUrl(url);
+
+      // We shouldn't report built-in search engines.
+      if (!id.endsWith("@search.mozilla.org")) {
+        addonId = id;
+      }
+    }
+
+    if (!addonId) {
+      // No add-on ID means there is nothing we can report.
+      return;
+    }
+
+    // This is the (initial) URL before the redirect.
+    const from = await browser.addonsSearchExperiment.getPublicSuffix(url);
+
+    // This is the URL after the redirect.
+    const requestUrl =
+      redirectUrl ||
+      (await browser.addonsSearchExperiment.getRequestUrl(requestId));
+    const to = await browser.addonsSearchExperiment.getPublicSuffix(requestUrl);
+
+    if (from === to) {
+      // We do not report redirects to same public suffixes.
+      return;
+    }
+
+    // Hopefully this is "all" we need to prevent multiple Telemetry event
+    // submissions, which might happen when both `onBeforeRequest` and
+    // `onBeforeRedirect` listeners are called for the same request (which is
+    // possible depending on the order of the registered listeners).
+    this.lastRequestIdReported = requestId;
+
+    const telemetryObject = isServerSideRedirect
+      ? TELEMETRY_OBJECT_OTHER
+      : TELEMETRY_OBJECT_WEBREQUEST;
+
+    const telemetryValue = isServerSideRedirect
+      ? TELEMETRY_VALUE_SERVER
+      : TELEMETRY_VALUE_EXTENSION;
+
+    // Get the add-on details we need to send as extra props.
+    const addon = await browser.addonsSearchExperiment.getAddonById(addonId);
+
+    const telemetryExtra = {
+      addonId,
+      addonVersion: addon.version,
+      from,
+      to,
+    };
+
+    this.recordEvent(
+      TELEMETRY_METHOD_ETLD_CHANGE,
+      telemetryObject,
+      telemetryValue,
+      telemetryExtra
+    );
+  };
+
+  recordEvent(method, object, value, extra) {
+    console.debug(
+      `recording event: method=${method} object=${object} value=${value} extra=${JSON.stringify(
+        extra
+      )}`
+    );
+
+    browser.telemetry.recordEvent(
+      TELEMETRY_CATEGORY,
+      method,
+      object,
+      value,
+      extra
+    );
+  }
+
+  getAddonIdFromUrl(url) {
+    for (const pattern of Object.keys(this.matchPatternsMap)) {
+      const [urlPrefix] = pattern.split("*");
+
+      if (url.startsWith(urlPrefix)) {
+        return this.matchPatternsMap[pattern];
+      }
+    }
+
+    return null;
+  }
+}
+
+const start = async () => {
+  const exp = new AddonsSearchExperiment();
+  await exp.monitor();
+
+  browser.addonsSearchExperiment.onSearchEngineModified.addListener(
+    async (type) => {
+      switch (type) {
+        case "engine-added":
+        case "engine-removed":
+          // For these modified types, we want to reload the list of search
+          // engines that are monitored, which is why we break to let the rest
+          // of the code execute.
+          break;
+
+        default:
+          return;
+      }
+
+      await exp.monitor();
+    }
+  );
+};
+
+start();

--- a/extension/background.js
+++ b/extension/background.js
@@ -181,7 +181,7 @@ class AddonsSearchExperiment {
     // At this point, we observed a webRequest redirect initiated by an add-on,
     // which we want to report if both eTLDs are different. This is verified in
     // the `report()` method.
-    await this.report({
+    this.report({
       addonIds,
       url,
       redirectUrl,
@@ -246,7 +246,7 @@ class AddonsSearchExperiment {
     if (this.requestIdsToFollow.has(requestId)) {
       const { addonIds, chain } = this.requestIdsToFollow.get(requestId);
 
-      await this.report({
+      this.report({
         addonIds,
         url: chain[0],
         redirectUrl: chain[chain.length - 1],

--- a/extension/background.js
+++ b/extension/background.js
@@ -26,6 +26,8 @@ class AddonsSearchExperiment {
         record_on_release: true,
       },
     });
+
+    this.onRedirectedListener = this.onRedirectedListener.bind(this);
   }
 
   async getMatchPatterns() {
@@ -98,7 +100,7 @@ class AddonsSearchExperiment {
     // Do nothing.
   }
 
-  onRedirectedListener = async ({ addonId, firstUrl, lastUrl }) => {
+  async onRedirectedListener({ addonId, firstUrl, lastUrl }) {
     if (!firstUrl || !lastUrl) {
       // Something went wrong but there is nothing we can do at this point.
       return;
@@ -167,7 +169,7 @@ class AddonsSearchExperiment {
         extra
       );
     }
-  };
+  }
 
   getAddonIdsForUrl(url) {
     for (const pattern of Object.keys(this.matchPatterns)) {

--- a/extension/background.js
+++ b/extension/background.js
@@ -140,6 +140,12 @@ class AddonsSearchExperiment {
   };
 
   onRedirectHandler = async ({ addonId, redirectUrl, requestId, url }) => {
+    if (this.requestIdsToFollow.has(requestId)) {
+      // When the requestId is already present in the list of request IDs to
+      // follow, we don't need to re-execute the logic below.
+      return;
+    }
+
     // When we do not have an add-on ID (in the request property bag) and the
     // `redirectUrl` is different than the original URL. we likely detected a
     // search server-side redirect.
@@ -165,12 +171,10 @@ class AddonsSearchExperiment {
 
       // Pass metadata to the follow listener and "start following" this
       // request.
-      if (!this.requestIdsToFollow.has(requestId)) {
-        this.requestIdsToFollow.set(requestId, {
-          addonIds,
-          chain: [url, redirectUrl],
-        });
-      }
+      this.requestIdsToFollow.set(requestId, {
+        addonIds,
+        chain: [url, redirectUrl],
+      });
 
       // If we likely found a server-side redirect, we can stop there and let
       // the follow/unfollow logic do the rest and maybe report an actual

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -14,7 +14,7 @@
       "parent": {
         "scopes": ["addon_parent"],
         "script": "api.js",
-        "events": ["startup"],
+        "events": [],
         "paths": [["addonsSearchExperiment"]]
       }
     }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,0 +1,31 @@
+{
+  "manifest_version": 2,
+  "name": "Add-ons Search Experiment",
+  "applications": {
+    "gecko": {
+      "id": "addons-search-experiment@mozilla.com"
+    }
+  },
+  "version": "1.0.0",
+  "description": "",
+  "experiment_apis": {
+    "addonsSearchExperiment": {
+      "schema": "schema.json",
+      "parent": {
+        "scopes": ["addon_parent"],
+        "script": "api.js",
+        "events": ["startup"],
+        "paths": [["addonsSearchExperiment"]]
+      }
+    }
+  },
+  "permissions": [
+    "<all_urls>",
+    "telemetry",
+    "webRequest",
+    "webRequestBlocking"
+  ],
+  "background": {
+    "scripts": ["background.js"]
+  }
+}

--- a/extension/schema.json
+++ b/extension/schema.json
@@ -1,0 +1,52 @@
+[
+  {
+    "namespace": "addonsSearchExperiment",
+    "functions": [
+      {
+        "name": "getMatchPatterns",
+        "type": "function",
+        "async": true,
+        "parameters": []
+      },
+      {
+        "name": "getRequestProperty",
+        "type": "function",
+        "async": true,
+        "parameters": [
+          { "name": "requestId", "type": "string" },
+          { "name": "propertyName", "type": "string" }
+        ]
+      },
+      {
+        "name": "getRequestUrl",
+        "type": "function",
+        "async": true,
+        "parameters": [{ "name": "requestId", "type": "string" }]
+      },
+      {
+        "name": "getAddonById",
+        "type": "function",
+        "async": true,
+        "parameters": [{ "name": "addonId", "type": "string" }]
+      },
+      {
+        "name": "getPublicSuffix",
+        "type": "function",
+        "async": true,
+        "parameters": [{ "name": "url", "type": "string" }]
+      }
+    ],
+    "events": [
+      {
+        "name": "onSearchEngineModified",
+        "type": "function",
+        "parameters": [
+          {
+            "name": "type",
+            "type": "string"
+          }
+        ]
+      }
+    ]
+  }
+]

--- a/extension/schema.json
+++ b/extension/schema.json
@@ -28,7 +28,7 @@
         "parameters": []
       },
       {
-        "name": "onBeforeRedirect",
+        "name": "onRedirected",
         "type": "function",
         "parameters": [
           {
@@ -36,9 +36,8 @@
             "type": "object",
             "properties": {
               "addonId": { "type": "string" },
-              "redirectUrl": { "type": "string" },
-              "requestId": { "type": "string" },
-              "url": { "type": "string" }
+              "firstUrl": { "type": "string" },
+              "lastUrl": { "type": "string" }
             }
           }
         ],

--- a/extension/schema.json
+++ b/extension/schema.json
@@ -9,15 +9,6 @@
         "parameters": []
       },
       {
-        "name": "getRequestProperty",
-        "type": "function",
-        "async": true,
-        "parameters": [
-          { "name": "requestId", "type": "string" },
-          { "name": "propertyName", "type": "string" }
-        ]
-      },
-      {
         "name": "getAddonVersion",
         "type": "function",
         "async": true,
@@ -35,6 +26,35 @@
         "name": "onSearchEngineModified",
         "type": "function",
         "parameters": []
+      },
+      {
+        "name": "onBeforeRedirect",
+        "type": "function",
+        "parameters": [
+          {
+            "name": "details",
+            "type": "object",
+            "properties": {
+              "addonId": { "type": "string" },
+              "redirectUrl": { "type": "string" },
+              "requestId": { "type": "string" },
+              "url": { "type": "string" }
+            }
+          }
+        ],
+        "extraParameters": [
+          {
+            "name": "filter",
+            "type": "object",
+            "properties": {
+              "urls": {
+                "type": "array",
+                "items": { "type": "string" },
+                "minItems": 1
+              }
+            }
+          }
+        ]
       }
     ]
   }

--- a/extension/schema.json
+++ b/extension/schema.json
@@ -18,13 +18,7 @@
         ]
       },
       {
-        "name": "getRequestUrl",
-        "type": "function",
-        "async": true,
-        "parameters": [{ "name": "requestId", "type": "string" }]
-      },
-      {
-        "name": "getAddonById",
+        "name": "getAddonVersion",
         "type": "function",
         "async": true,
         "parameters": [{ "name": "addonId", "type": "string" }]

--- a/extension/schema.json
+++ b/extension/schema.json
@@ -34,12 +34,7 @@
       {
         "name": "onSearchEngineModified",
         "type": "function",
-        "parameters": [
-          {
-            "name": "type",
-            "type": "string"
-          }
-        ]
+        "parameters": []
       }
     ]
   }


### PR DESCRIPTION
This first version reports information to Telemetry for eTLDs (public suffixes) and `webRequest` as per the PRD. Once loaded, the extension should do its thing automatically. It listens to search engine modifications and updates itself accordingly.

Some more information about this patch (in no particular order):

- We only record an event when `from` and `to` values are different (the values are eTLDs fwiw) to comply with the data review
- When we find a redirect caused by an extension (_via_ `webRequest`), we record an event and we don't check for server-side redirects
- We follow redirect chains and only record an event when the first and last URLs have different eTLDs
- We only record an event when we have an add-on ID (or more than one)
- In case of multiple extensions, we record an event for each add-on ID