### PR TITLE
Set xpiSigningType to `system`

### DIFF
--- a/.taskcluster.yml
+++ b/.taskcluster.yml
@@ -13,7 +13,7 @@ tasks:
           # `mozillaonline-privileged` for Mozilla China add-on,
           # `normandy-privileged` for normandy add-on
           # to enable siging on push/PR.
-          xpiSigningType: ""
+          xpiSigningType: "system"
           # The below doesn't need changing on initial repo setup
           taskgraph:
               branch: taskgraph


### PR DESCRIPTION
This is needed to enable signing according to [these instructions](https://github.com/mozilla-extensions/xpi-manifest/blob/master/docs/adding-a-new-xpi.md#enable-signing-on-push).

See also: https://github.com/mozilla-extensions/xpi-manifest/pull/123