### PR TITLE
Exclude search engines without an extension ID (like OpenSearch)

### DIFF
--- a/extension/api.js
+++ b/extension/api.js
@@ -56,6 +56,11 @@ this.addonsSearchExperiment = class extends ExtensionAPI {
             visibleEngines.forEach((engine) => {
               const { _extensionID, _urls } = engine;
 
+              if (!_extensionID) {
+                // OpenSearch engines don't have an extension ID.
+                return;
+              }
+
               _urls
                 // We only want to collect "search URLs" (and not "suggestion"
                 // ones for instance). See `URL_TYPE` in `SearchUtils.jsm`.


### PR DESCRIPTION
I installed a dev-signed XPI on my main Nightly browser and discovered this issue. Below is the search engine that causes an issue in `getMatchPatterns()`:

```js
{
  "_name": "LEO Eng-Ger",
  "_loadPath": "[https]dict.leo.org/leo-eng-ger.xml",
  "description": "Use LEOs English-German online dictionary to translate words or phrase from English to German or vice versa.",
  "__searchForm": "https://dict.leo.org",
  "_iconURL": "data:image/x-icon;base64,AAABAAEAEBAAAAEAGABoAwAAFgAAACgAAAAQAAAAIAAAAAEAGAAAAAAAAAAAAEgAAABIAAAAAAAAAAAAAACh0vp3ad+nb158HwB8IgB5HACnalJeTuBVReGpcF14GwB9IwB1FwCrcFb++/WRiOoj1f94o8I/PlZWUU86JB01EQdXNyo/NJZFOLecaFZ1GQB1FwCrcFf//viQh+5lU9gJyfY1UFXy///0///p+Pjc6uq3wsKQmZlsc3dVU1I9LCpEMCiCgX9lX6pjU82nbFgGxPEYWWiYoaHx///v///M2trj8/P6///////////0///g7u67xsaQlZVPSkdUEwAHy/EAx/YKQE7u/f2lsLArJklQRkU5OVFdYWiMk5O7xcXj8fH0///////0//9EQT8MnvMA2f8NV2nx//+IkZGCr8Tw7/9dTdVGNbmvr69+f39OTF5YV1ZbW1hhYmBfVk8HFOAAmPYLWmfw//+IkpIToMGXzPdXRdk6JdJ/ceKBc+OIfOSCduKAduN/duKGfe8CANsADt8IRGjq+/uPmZkAlbgZ0/99s/JFMdUfB8wfBswfBswfBswfBswfBswfBswCANwAANwFC2nY6Oikrq4AgqEAzv8Z0/9+svI7JtMeBcweBcweBcweBcweBcweBcwIB+IAAN0CAXTD0dHAzc0BcYMAzv8Azv8Z0/+Wz/ielOmIe+SIfeiNhfGOhvKOhvIMCs0AAOQAAH+0wcHY5uYFRGwA2/8Azv8Azv8Z0/+n4Pz////88+PVsp3ZuaTau6UHAjIAAM4AAIawvb3n+PgJDlkAmPYA2v8Azv8Azv8Z0/+Wz/v8+PStclhyEgB5HQAHAgAAADIAAH+otLTn9/cICFoADN4AlPUA2/8Azv8Azv8Z0/+W0Pv//vuweF91FgAJBgUAAAAAACaDjIy+y8sBAXMAANwADd4AmPYA2v8Azv8Azv8Z0/+Wz/v///yweWEGBQwAAAAAAAAPECIcHkoAAMsAAN0AANwADN4AlPUA2f8Azv8Azv8Z0/+U0Pr//v0PDRgKCgoJBgUGAQAHAjIHAsMJBtkFBN0FBNwJEtcHlOkHy/EHxPEHyvca0v+c0PkAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
  "_metaData": {
    "loadPathHash": "luFBvS36DcfCYZg8coLPh+UspPEg5OFOtditIO9tzxk=",
    "order": 1,
    "updateexpir": 1550159876681,
    "alias": "leo",
    "updatelastmodified": "Thu, 07 Feb 2019 15:57:56 GMT"
  },
  "_urls": [
    {
      "params": [],
      "rels": [],
      "template": "https://dict.leo.org/german-english/{searchTerms}"
    },
    {
      "params": [],
      "rels": [],
      "template": "https://dict.leo.org/dictQuery/m-query/conf/ende/query.conf/strlist.json?q={searchTerms}&sort=PLa&shortQuery&noDescription&noQueryURLs",
      "type": "application/x-suggestions+json"
    },
    {
      "params": [],
      "rels": [
        "self"
      ],
      "template": "https://dict.leo.org/pages/helpers/shared/searches/opensearch_ende_en.xml",
      "type": "application/opensearchdescription+xml"
    }
  ],
  "_isAppProvided": false,
  "_orderHint": null,
  "_telemetryId": null,
  "_updateInterval": null,
  "_updateURL": null,
  "_iconUpdateURL": null,
  "_filePath": null,
  "_extensionID": null,
  "_locale": null,
  "_definedAliases": []
}
```