### PR TITLE
Rename extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# addons-search-experiment
+# addons-search-detection
 
 ## Super Quick Start
 
@@ -10,9 +10,9 @@ $ yarn web-ext run -s extension --pref "extensions.experiments.enabled=true"
 ## Development XPIs
 
 TaskCluster should build and sign development XPIs for each commit. Open the
-`dep-signing-addons-search-experiment` CI check from GitHub, then click on "View
+`dep-signing-addons-search-detection` CI check from GitHub, then click on "View
 task in Taskcluster". On TaskCluster, look for the "Artifacts" section, which
-should have a link to this file: `public/build/addons-search-experiment.xpi`.
+should have a link to this file: `public/build/addons-search-detection.xpi`.
 Clicking the link will start the install process.
 
 As documented [here][doc-xpi-dev], only Nightly and unbranded FF will accept to

--- a/data.md
+++ b/data.md
@@ -1,4 +1,4 @@
-# Add-ons Search Experiment Pings
+# Add-ons Search Detection Pings
 
 This add-on will collect information about search engines.
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,9 +1,9 @@
 {
   "manifest_version": 2,
-  "name": "Add-ons Search Experiment",
+  "name": "Add-ons Search Detection",
   "applications": {
     "gecko": {
-      "id": "addons-search-experiment@mozilla.com"
+      "id": "addons-search-detection@mozilla.com"
     }
   },
   "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "addons-search-experiment",
+  "name": "addons-search-detection",
   "version": "1.0.0",
-  "repository": "https://github.com/mozilla-extensions/addons-search-experiment",
+  "repository": "https://github.com/mozilla-extensions/addons-search-detection",
   "license": "MPLv2",
   "private": true,
   "devDependencies": {
     "web-ext": "^6.2.0"
   },
   "scripts": {
-    "build": "web-ext build -s extension --overwrite-dest --filename addons-search-experiment.xpi",
+    "build": "web-ext build -s extension --overwrite-dest --filename addons-search-detection.xpi",
     "lint": "web-ext lint -s extension"
   }
 }


### PR DESCRIPTION
The term `experiment` wasn't really accurate.

**Important:** the repo should be renamed.